### PR TITLE
Event listener to MediaQueryList

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,11 +7,9 @@ const useMediaQuery = query => {
     const updateMatch = () => setMatch(window.matchMedia(query).matches)
 
     updateMatch()
-    window.addEventListener('resize', updateMatch)
-    window.addEventListener('orientationchange', updateMatch)
+    window.matchMedia(query).addEventListener("change", updateMatch)
     return () => {
-      window.removeEventListener('resize', updateMatch)
-      window.removeEventListener('orientationchange', updateMatch)
+      window.matchMedia(query).removeEventListener("change", updateMatch)
     }
   }, [])
 

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,7 @@ const useMediaQuery = query => {
     return () => {
       window.matchMedia(query).removeEventListener("change", updateMatch)
     }
-  }, [])
+  }, [query])
 
   return match
 }

--- a/src/index.js
+++ b/src/index.js
@@ -3,9 +3,9 @@ import {useState, useEffect} from 'react'
 const useMediaQuery = query => {
   const [match, setMatch] = useState(false)
 
-  const updateMatch = () => setMatch(window.matchMedia(query).matches)
-
   useEffect(() => {
+    const updateMatch = () => setMatch(window.matchMedia(query).matches)
+
     updateMatch()
     window.addEventListener('resize', updateMatch)
     window.addEventListener('orientationchange', updateMatch)


### PR DESCRIPTION
This PR makes mainly changes to the events. It uses the change event on MediaQueryList as proposed by #2 . Besides, it adds `query` to the useEffects deps and moves `updateMatch` inside the useEffect function to comply with react-hooks eslint rules.