### PR TITLE
Fix memory leak issue and clean up code

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,12 +4,13 @@ const useMediaQuery = query => {
   const [match, setMatch] = useState(false)
 
   useEffect(() => {
-    const updateMatch = () =>
-      setMatch(window.matchMedia(query).matches)
+    const updateMatch = event => setMatch(event.matches)
 
-    updateMatch()
     const matcher = window.matchMedia(query)
       .addEventListener("change", updateMatch)
+    
+    updateMatch(matcher)
+
     return () => {
       matcher.removeEventListener("change", updateMatch)
     }

--- a/src/index.js
+++ b/src/index.js
@@ -8,11 +8,10 @@ const useMediaQuery = query => {
       setMatch(window.matchMedia(query).matches)
 
     updateMatch()
-    window.matchMedia(query)
+    const matcher = window.matchMedia(query)
       .addEventListener("change", updateMatch)
     return () => {
-      window.matchMedia(query)
-        .removeEventListener("change", updateMatch)
+      matcher.removeEventListener("change", updateMatch)
     }
   }, [query])
 

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,8 @@ const useMediaQuery = query => {
     const updateMatch = event => setMatch(event.matches)
 
     const matcher = window.matchMedia(query)
-      .addEventListener("change", updateMatch)
+
+    matcher.addEventListener("change", updateMatch)
     
     updateMatch(matcher)
 

--- a/src/index.js
+++ b/src/index.js
@@ -8,12 +8,21 @@ const useMediaQuery = query => {
 
     const matcher = window.matchMedia(query)
 
-    matcher.addEventListener("change", updateMatch)
+    const modern = 'addEventListener' in matcher;
+    if (modern) {
+      matcher.addEventListener("change", updateMatch)
+    } else {
+      matcher.addListener(updateMatch);
+    }
     
     updateMatch(matcher)
 
     return () => {
-      matcher.removeEventListener("change", updateMatch)
+      if (modern) {
+        matcher.removeEventListener("change", updateMatch)
+      } else {
+        matcher.removeListener(updateMatch)
+      }
     }
   }, [query])
 


### PR DESCRIPTION
Hi,

I've added some small changes to capture the MediaQueryList object returned from matchMedia. This is used to remove and add event listener, which fixes an issue where the event listeners are never removed.

It also includes taking the `matches` property given by the change event

Edit: this also includes support for iOS, since it relies on the deprecated (add/remove)Listener methods, not the (add/remove)EventListener methdos.